### PR TITLE
Alignment for print and small layout improvements

### DIFF
--- a/AveryLabels.py
+++ b/AveryLabels.py
@@ -26,6 +26,7 @@ labelInfo = {
     3044: (2, 11, (32, 10), (2, 2), (1, 1), (66.5 * mm, 120.5 * mm)),
     # 189x 25.4mm x 10mm mini labels
     4731: (7, 27, (25.4 * mm, 10 * mm), (2.5 * mm, 0), (9 * mm, 13.5 * mm), A4),
+    7871: (7, 27, (25.4 * mm, 10 * mm), (2.5 * mm, 0), (9 * mm, 13.5 * mm), A4),
     # 2.6 x 1 address labels
     5160: (3, 10, (187, 72), (11, 0), (14, 36), A4),
     5161: (2, 10, (288, 72), (0, 0), (18, 36), A4),
@@ -44,7 +45,7 @@ labelInfo = {
 
 class AveryLabel:
 
-    def __init__(self, label, **kwargs):
+    def __init__(self, label, pageoffset, **kwargs):
         data = labelInfo[label]
         self.across = data[0]
         self.down = data[1]
@@ -55,6 +56,8 @@ class AveryLabel:
         self.debug = False
         self.pagesize = data[5]
         self.position = 0
+        self.pageoffset = pageoffset
+
         self.__dict__.update(kwargs)
 
     def open(self, filename):
@@ -76,8 +79,8 @@ class AveryLabel:
                 y, x = divmod(x, self.across)
 
         return (
-            self.margins[0] + x * self.labelsep[0],
-            self.pagesize[1] - self.margins[1] - (y + 1) * self.labelsep[1],
+            self.margins[0] + x * self.labelsep[0] + self.pageoffset[0],
+            self.pagesize[1] - self.margins[1] - (y + 1) * self.labelsep[1] - self.pageoffset[1],
         )
 
     def advance(self):
@@ -101,7 +104,7 @@ class AveryLabel:
     # Or, pass a callable and an iterator.  We'll do one label
     # per iteration of the iterator.
 
-    def render(self, thing, count, offset=0, *args):
+    def render(self, thing, count, offset=0, pageshift=(0 * mm, 0 * mm), *args):
         """ render loop"""
         assert callable(thing) or isinstance(thing, str)
         if isinstance(count, Iterator):
@@ -128,6 +131,7 @@ class AveryLabel:
         canv = self.canvas
         for chunk in iterator:
             canv.saveState()
+
             canv.translate(*self.top_left())
             if self.debug:
                 canv.setLineWidth(0.25)

--- a/README.md
+++ b/README.md
@@ -65,31 +65,38 @@ Usage: asn-gen.py [OPTIONS] [filename]
 ASN Label Generator
 
 Arguments:
-  filename                          output filename of PDF file generated
+  filename                    output filename of PDF file generated, if .pdf extension is missing the string will be used
+                              as directory
 
 Options:
-  -l, --labeltype=STR               Type of label, e.g. 4731, get a list of supported labels with --labels (default: 4731)
-  -n, --number=INT                  number of labels to generate (default: 189)
-  -o, --offset=INT                  Number of labels to skip on the first sheet (e.g. already used) (default: 0)
-  -d, --num-digits=INT              Number of digits for the ASN, e.g. 000001 (default: 6)
-  -s, --first-asn=INT               First ASN to use, e.g. 100001 (default: 1)
-  -f, --font-size=STR               Fontsize with a unit, e.g. 2mm, 0.4cm (default: 2mm)
-  -q, --qr-size=FLOAT               Size of the QR-Code as percentage of the label hight (default: 0.9)
-  -m, --qr-margin=STR               Margin around the QR-Code with a unit, e.g. 1mm (default: 1mm)
-  --sub-labels-x, --lx=INT          How many labels to put on a phyical label horizontally (default: 1)
-  --sub-labels-y, --ly=INT          How many labels to put on a phyical label vertically (default: 1)
-  --debug                           enable debug mode
-  --position-helper                 enable position helpers, e.g. as cutting guides when using sub labels
-  --bar-width, --bw=INT             Show a colored bar on the right of the label (0 = no bar) (default: 0)
-  --bar-color, --bc=STR             Color of the bar, HEX notation (default: d2dede)
-  --highlight-bar-width, --hw=INT   add a colored highlight bar on the right of the label (0 = no bar) (default: 0)
-  --highlight-bar-color, --hc=STR   Color of the highlight bar, HEX notation (default: d9a4a6)
-  -p, --prefix=STR                  Prefix to the actual ASN number (default: ASN)
+  -l, --labeltype=STR         Type of label, e.g. 4731, get a list of supported labels with --labels (default: 4731)
+  -n, --number=INT            number of labels to generate (default: 189)
+  -o, --offset=INT            Number of labels to skip on the first sheet (e.g. already used) (default: 0)
+  -d, --num-digits=INT        Number of digits for the ASN, e.g. 000001 (default: 6)
+  -s, --first-asn=INT         First ASN to use, e.g. 100001 (default: 1)
+  -f, --font-size=STR         Fontsize with a unit, e.g. 2mm, 0.4cm (default: 2mm)
+  -q, --qr-size=FLOAT         Size of the QR-Code as percentage of the label hight (default: 0.9)
+  -m, --qr-margin=STR         Margin around the QR-Code with a unit, e.g. 1mm (default: 1mm)
+  --sub-labels-x, --lx=INT    How many labels to put on a phyical label horizontally (default: 1)
+  --sub-labels-y, --ly=INT    How many labels to put on a phyical label vertically (default: 1)
+  --debug                     enable debug mode
+  --position-helper           enable position helpers, e.g. as cutting guides when using sub labels
+  --bar-width, --bw=INT       Show a colored bar on the right of the label (0 = no bar) (default: 0)
+  --bar-color, --bc=STR       Color of the bar, HEX notation (default: d2dede)
+  --highlight-bar-width, --hw=INT
+                              add a colored highlight bar on the right of the label (0 = no bar) (default: 0)
+  --highlight-bar-color, --hc=STR
+                              Color of the highlight bar, HEX notation (default: d9a4a6)
+  -p, --prefix=STR            Prefix to the actual ASN number (default: ASN)
+  --page-offset-x, --dx=STR   Print offset of the labels on the page to handle horizontal printer alignment with unit
+                              (e.g. -2mm) (default: 0mm)
+  --page-offset-y, --dy=STR   Print offset of the labels on the page to handle vertical printer alignment with unit (e.g.
+                              -1.5mm) (default: 0mm)
 
 Other actions:
-  -h, --help                        Show the help
-  --labels                          Shows a list of supported labels
-  --version                         Show the version
+  -h, --help                  Show the help
+  --labels                    Shows a list of supported labels
+  --version                   Show the version
 ```
 
 #### Testing your printer settings


### PR DESCRIPTION
* options to handle invalid vertical and/or horizontal printer alignment
* remove additional padding from qr code
* use qr code margin option also as minimum spacing to upper and lower label border
* fix positioning of ASN number
* Add Avery L7871 label definition (it's a clone of 4731)