### PR TITLE
Fix filename generation logic in asn-gen.py

### DIFF
--- a/asn-gen.py
+++ b/asn-gen.py
@@ -141,7 +141,7 @@ def gen_filename(parm):
     return '-'.join(['label',
                      str(parm["labeltype"]), parm["prefix"],
                      str(parm["first_asn"]).zfill(parm["num_digits"]),
-                     str(parm["first_asn"] + parm["number"]).zfill(parm["num_digits"])
+                     str(parm["first_asn"] + parm["number"] - 1).zfill(parm["num_digits"])
                      ])+'.pdf'
 
 


### PR DESCRIPTION
This pull request makes a small but important fix to the filename generation logic in `asn-gen.py`. The change ensures that the filename correctly reflects the intended range of ASNs by adjusting the calculation of the last ASN in the range.

- The `gen_filename` function now subtracts 1 from the sum of `first_asn` and `number` to accurately represent the last ASN in the generated filename.